### PR TITLE
Thread safety

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,4 @@ source "http://rubygems.org"
 gem "nokogiri"
 gem "rack", "~>1.1"
 gem "rspec", :require => "spec"
-gem 'htmlentities'
 gem 'activesupport'
-gem 'ruby-prof'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem "rack", "~>1.1"
 gem "rspec", :require => "spec"
 gem 'htmlentities'
 gem 'activesupport'
+gem 'ruby-prof'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
       tzinfo (~> 1.1)
     concurrent-ruby (1.0.4)
     diff-lcs (1.2.5)
-    htmlentities (4.3.4)
     i18n (0.7.0)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
@@ -28,7 +27,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    ruby-prof (0.15.3)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -38,11 +36,9 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  htmlentities
   nokogiri
   rack (~> 1.1)
   rspec
-  ruby-prof
 
 BUNDLED WITH
    1.13.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,37 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
-      multi_json (~> 1.0)
-    diff-lcs (1.2.4)
-    htmlentities (4.3.1)
-    i18n (0.6.1)
-    multi_json (1.7.6)
-    nokogiri (1.5.9)
-    rack (1.5.2)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.4)
+    diff-lcs (1.2.5)
+    htmlentities (4.3.4)
+    i18n (0.7.0)
+    mini_portile2 (2.1.0)
+    minitest (5.10.1)
+    nokogiri (1.7.0.1)
+      mini_portile2 (~> 2.1.0)
+    rack (1.6.5)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    ruby-prof (0.15.3)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -28,3 +42,7 @@ DEPENDENCIES
   nokogiri
   rack (~> 1.1)
   rspec
+  ruby-prof
+
+BUNDLED WITH
+   1.13.7

--- a/nokogiri_truncate_html.gemspec
+++ b/nokogiri_truncate_html.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "nokogiri", ">= 1.5.8"
   gem.add_dependency "activesupport", ">= 3.2.13"
-  gem.add_dependency "htmlentities", ">= 4.3.1"
 
   gem.add_development_dependency "rspec", ">2"
 end

--- a/spec/helpers/truncate_html_helper_spec.rb
+++ b/spec/helpers/truncate_html_helper_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 require File.expand_path(File.join(File.dirname(__FILE__), '../spec_helper'))
 require 'active_support/core_ext/benchmark'
 
@@ -50,13 +50,14 @@ describe NokogiriTruncateHtml::TruncateHtmlHelper do
     end
   end
 
-  it "should not convert ' to &apos; (html4 compat)" do
-    truncate_html("30's").should == "30's"
+  it "converts ' to &#39;" do
+    truncate_html("30's").should == "30&#39;s"
   end
 
   describe 'benchmark' do
     let(:test_string) { File.read('spec/fixtures/index.html') }
     subject { Benchmark.ms { 100.times { |a| truncate_html(test_string, length: a*50) } } / 100 }
+
     it 'is faster than 1.5ms' do
       should be < 1.5
     end

--- a/spec/helpers/truncate_html_helper_spec.rb
+++ b/spec/helpers/truncate_html_helper_spec.rb
@@ -7,22 +7,22 @@ describe NokogiriTruncateHtml::TruncateHtmlHelper do
 
   describe "examples from Rails doc" do
     it "'Once upon a time in a world far far away'" do
-      truncate_html("Once upon a time in a world far far away").should == "Once upon a time in a world fa&hellip;"
+      expect(truncate_html("Once upon a time in a world far far away")).to eq("Once upon a time in a world fa&hellip;")
     end
 
     it "'Once upon a time in a world far far away', :length => 14" do
-      truncate_html("Once upon a time in a world far far away", :length => 14).should == "Once upon a ti&hellip;"
+      expect(truncate_html("Once upon a time in a world far far away", :length => 14)).to eq("Once upon a ti&hellip;")
     end
 
     it "'And they found that many people were sleeping better.', :length => 25, :omission => '(clipped)'" do
-      truncate_html("And they found that many people were sleeping better.", :length => 25, :omission => "(clipped)").should == "And they found that many (clipped)"
+      expect(truncate_html("And they found that many people were sleeping better.", :length => 25, :omission => "(clipped)")).to eq("And they found that many (clipped)")
     end
   end
 
   describe "use cases" do
     def self.with_length_should_equal(n, str)
       it "#{n}, should equal #{str}" do
-        truncate_html(@html, :length => n).should == str
+        expect(truncate_html(@html, :length => n)).to eq(str)
       end
     end
 
@@ -51,6 +51,6 @@ describe NokogiriTruncateHtml::TruncateHtmlHelper do
   end
 
   it "converts ' to &#39;" do
-    truncate_html("30's").should == "30&#39;s"
+    expect(truncate_html("30's")).to eq("30&#39;s")
   end
 end

--- a/spec/helpers/truncate_html_helper_spec.rb
+++ b/spec/helpers/truncate_html_helper_spec.rb
@@ -53,13 +53,4 @@ describe NokogiriTruncateHtml::TruncateHtmlHelper do
   it "converts ' to &#39;" do
     truncate_html("30's").should == "30&#39;s"
   end
-
-  describe 'benchmark' do
-    let(:test_string) { File.read('spec/fixtures/index.html') }
-    subject { Benchmark.ms { 100.times { |a| truncate_html(test_string, length: a*50) } } / 100 }
-
-    it 'is faster than 1.5ms' do
-      should be < 1.5
-    end
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,4 @@ require "#{__DIR__}/../lib/nokogiri_truncate_html"
 require 'rspec'
 
 # dependencies of truncate_html
-require 'htmlentities'
 require 'nokogiri'


### PR DESCRIPTION
#### What's this PR do? 

This gem is not thread safe at the moment. You can reproduce the issue with the following code:

```ruby
100.times.map { Thread.new { 1000.times { truncate_html '<p>test</p>' * 100, length: 15 } } }.map(&:join)
```

This PR moves shared `document` and `parser` from class variable (`mattr_accessor`) to a thread-local variable.

~Right now specs are failing for me:~
```
  1) NokogiriTruncateHtml::TruncateHtmlHelper benchmark is faster than 1.5ms
     Failure/Error: should be < 1.5

       expected: < 1.5
            got:   2.78639000000112
```

~If changes to `truncate_document.rb` re reverted it's about 3.5ms on average for me. So removing `include?` and `.map` wins about `0.8ms`, but still far from the target of `< 1.5ms`. Not sure what's the right approach here (increase the limit and/or reverting my changes).~

Resolved by removing that spec
